### PR TITLE
Modify axes for similar method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Coordinates"
 uuid = "15ac8fbd-cb39-4be8-bb90-8f74d06af8f8"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [compat]
 julia = "1"

--- a/src/Coordinates.jl
+++ b/src/Coordinates.jl
@@ -74,6 +74,8 @@ Base.size(A::Coordinate) = map(length, coordinateaxes(A))
 
 _eachindex(x) = firstindex(x):lastindex(x)
 _eachindex(x::AbstractArray) = eachindex(x)
+_eachindex(x::AbstractVector) = only(axes(x)) # should return Base.OneTo
+_eachindex(x::Tuple) = only(axes(x))          # should return Base.OneTo
 Base.axes(A::Coordinate) = map(_eachindex, coordinateaxes(A))
 
 # getindex


### PR DESCRIPTION
`similar(Coordinate((1,2),(1,2)))` fails before this PR.